### PR TITLE
fix: CUDOS-1442 Showing only one of multiple "redelegations" or "undelegations"

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -104,8 +104,13 @@ const Table: React.FC<TableProps> = ({
       >
         <MuiTable sx={{ tableLayout: 'fixed' }}>
           <TableBody>
-            {items.map((item: any) => (
-              <TableRow key={item.idx}>
+            {items.map((item: any, index: number) => (
+              <TableRow
+                key={item.idx}
+                sx={({ custom }) => ({
+                  background: index % 2 !== 0 ? custom.backgrounds.light : null
+                })}
+              >
                 {columns.map((col: any) => (
                   <TableCell
                     key={col.key}

--- a/src/containers/ValidatorDetails/components/Delegators/components/Redelegations/index.tsx
+++ b/src/containers/ValidatorDetails/components/Delegators/components/Redelegations/index.tsx
@@ -91,31 +91,32 @@ const Redelegations: React.FC<RedelegationsProps> = (props) => {
       </Tooltip>
     ),
     amount: (
-      <Stack direction="row" gap={1} alignItems="center">
-        <Box>
-          <img src={CudosLogo} alt="Cudos Logo" />
-        </Box>
-        <Typography color="text.primary">
-          {formatNumber(
-            item.entries[0].amount.value,
-            item.entries[0].amount.exponent
-          )}
-        </Typography>
-        <Typography>
-          {item.entries[0].amount.displayDenom.toUpperCase()}
-        </Typography>
+      <Stack gap={1} alignItems="flex-start">
+        {item.entries.map((entry) => (
+          <Stack key={entry.completionTime} direction="row" gap={1}>
+            <Box>
+              <img src={CudosLogo} alt="Cudos Logo" />
+            </Box>
+            <Typography color="text.primary">
+              {formatNumber(entry.amount.value, entry.amount.exponent)}
+            </Typography>
+            <Typography>{entry.amount.displayDenom.toUpperCase()}</Typography>
+          </Stack>
+        ))}
       </Stack>
     ),
     completionTime: (
-      <Stack direction="row" gap={1} alignItems="center">
-        <AccessTimeRoundedIcon color="primary" />
-        <Typography fontSize={12} color="text.secondary">
-          {moment(
-            moment(item.entries[0].completionTime).parseZone().toLocaleString()
-          )
-            .format('DD MMM YYYY LTS')
-            .toLocaleString()}
-        </Typography>
+      <Stack gap={1} alignItems="flex-start">
+        {item.entries.map((entry) => (
+          <Stack key={entry.completionTime} direction="row" gap={1}>
+            <AccessTimeRoundedIcon color="primary" />
+            <Typography fontSize={12} color="text.secondary">
+              {moment(moment(entry.completionTime).parseZone().toLocaleString())
+                .format('DD MMM YYYY LTS')
+                .toLocaleString()}
+            </Typography>
+          </Stack>
+        ))}
       </Stack>
     )
   }))

--- a/src/containers/ValidatorDetails/components/Delegators/components/Unbondings/index.tsx
+++ b/src/containers/ValidatorDetails/components/Delegators/components/Unbondings/index.tsx
@@ -63,31 +63,32 @@ const Unbondings: React.FC<UnbondingsProps> = (props) => {
       </Tooltip>
     ),
     amount: (
-      <Stack direction="row" gap={1} alignItems="center">
-        <Box>
-          <img src={CudosLogo} alt="Cudos Logo" />
-        </Box>
-        <Typography color="text.primary">
-          {formatNumber(
-            item.entries[0].amount.value,
-            item.entries[0].amount.exponent
-          )}
-        </Typography>
-        <Typography>
-          {item.entries[0].amount.displayDenom.toUpperCase()}
-        </Typography>
+      <Stack gap={1} alignItems="flex-start">
+        {item.entries.map((entry) => (
+          <Stack key={entry.completionTime} direction="row" gap={1}>
+            <Box>
+              <img src={CudosLogo} alt="Cudos Logo" />
+            </Box>
+            <Typography color="text.primary">
+              {formatNumber(entry.amount.value, entry.amount.exponent)}
+            </Typography>
+            <Typography>{entry.amount.displayDenom.toUpperCase()}</Typography>
+          </Stack>
+        ))}
       </Stack>
     ),
     completionTime: (
-      <Stack direction="row" gap={1} alignItems="center">
-        <AccessTimeRoundedIcon color="primary" />
-        <Typography fontSize={12} color="text.secondary">
-          {moment(
-            moment(item.entries[0].completionTime).parseZone().toLocaleString()
-          )
-            .format('DD MMM YYYY LTS')
-            .toLocaleString()}
-        </Typography>
+      <Stack gap={1} alignItems="flex-start">
+        {item.entries.map((entry) => (
+          <Stack key={entry.completionTime} direction="row" gap={1}>
+            <AccessTimeRoundedIcon color="primary" />
+            <Typography fontSize={12} color="text.secondary">
+              {moment(moment(entry.completionTime).parseZone().toLocaleString())
+                .format('DD MMM YYYY LTS')
+                .toLocaleString()}
+            </Typography>
+          </Stack>
+        ))}
       </Stack>
     )
   }))


### PR DESCRIPTION
Iterating through all of the amounts of "redelegations" (possible max 7) and "undelegations" from by a delegator from a validator.

Colouring the background of every 2nd row in the tables for better visibility