### PR TITLE
CUDOS-1746 Update wallet balance after transaction finishes

### DIFF
--- a/src/components/Dialog/components/DelegationModal/Delegation.tsx
+++ b/src/components/Dialog/components/DelegationModal/Delegation.tsx
@@ -30,7 +30,7 @@ import { formatNumber, formatToken } from 'utils/format_token'
 import _ from 'lodash'
 import { signingClient } from 'ledgers/utils'
 import { updateUser } from 'store/profile'
-import { getStakedBalance } from 'utils/projectUtils'
+import { getStakedBalance, getWalletBalance } from 'utils/projectUtils'
 import { fetchDelegations } from 'api/getAccountDelegations'
 import {
   ModalContainer,
@@ -172,11 +172,13 @@ const Delegation: React.FC<DelegationProps> = ({ modalProps, handleModal }) => {
         txHash: delegationResult.transactionHash
       })
 
+      const walletBalance = await getWalletBalance(address)
       const { delegationsArray } = await fetchDelegations(address)
       const stakedAmountBalance = await getStakedBalance(address)
 
       dispatch(
         updateUser({
+          balance: walletBalance,
           delegations: delegationsArray,
           stakedBalance: new BigNumber(stakedAmountBalance)
         })
@@ -394,9 +396,12 @@ const Delegation: React.FC<DelegationProps> = ({ modalProps, handleModal }) => {
             sx={() => ({
               width: '50%'
             })}
-            onClick={handleSubmit}
+            onClick={() => handleSubmit()}
             disabled={
-              Number(amount) > Number(balance) || !amount || Number(amount) <= 0
+              Number(amount) > Number(balance) ||
+              !amount ||
+              Number(amount) <= 0 ||
+              fee.length <= 0
             }
           >
             Submit

--- a/src/containers/Dashboard/WalletInformation/components/ClaimRewardsModal/Rewards.tsx
+++ b/src/containers/Dashboard/WalletInformation/components/ClaimRewardsModal/Rewards.tsx
@@ -33,6 +33,7 @@ import {
 import { ValidatorType } from 'store/validator'
 import { toValidatorAddress } from 'utils/prefix_convert'
 import useValidators from 'containers/Staking/components/Validators/components/Table/hooks'
+import { getWalletBalance } from 'utils/projectUtils'
 
 type RewardsProps = {
   modalProps: RewardsModalProps
@@ -90,7 +91,15 @@ const Rewards: React.FC<RewardsProps> = ({ modalProps, handleModal }) => {
         fee: formatToken(fee, CosmosNetworkConfig.CURRENCY_DENOM).value
       })
 
-      dispatch(updateUser({ availableRewards: new BigNumber(0) }))
+      const walletBalance = await getWalletBalance(address)
+      const { totalRewards } = await fetchRewards(address)
+
+      dispatch(
+        updateUser({
+          availableRewards: new BigNumber(totalRewards),
+          balance: walletBalance
+        })
+      )
     } catch (err) {
       handleModal({
         status: ModalStatus.FAILURE,

--- a/src/containers/Proposals/components/DepositModal/Deposit.tsx
+++ b/src/containers/Proposals/components/DepositModal/Deposit.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useState } from 'react'
 import { Box, Button, Typography } from '@mui/material'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'store'
 import { depositProposal } from 'ledgers/transactions'
 import BigNumber from 'bignumber.js'
@@ -11,6 +11,8 @@ import {
   initialDepositModalState,
   ModalStatus
 } from 'store/modal'
+import { getWalletBalance } from 'utils/projectUtils'
+import { updateUser } from 'store/profile'
 import { CancelRoundedIcon, ModalContainer, StyledTextField } from './styles'
 
 type DepositProps = {
@@ -25,6 +27,8 @@ const Deposit: React.FC<DepositProps> = ({ handleModal, modalProps }) => {
   )
 
   const { id, title } = modalProps
+
+  const dispatch = useDispatch()
 
   const handleAmount = async (ev: ChangeEvent<HTMLInputElement>) => {
     setDepositAmount(ev.target.value)
@@ -58,6 +62,14 @@ const Deposit: React.FC<DepositProps> = ({ handleModal, modalProps }) => {
         fee: new BigNumber(gasFee),
         hash: result.transactionHash
       })
+
+      const walletBalance = await getWalletBalance(address)
+
+      dispatch(
+        updateUser({
+          balance: walletBalance
+        })
+      )
     } catch (error) {
       handleModal({
         open: true,

--- a/src/containers/Proposals/components/ProposalModal/Proposals.tsx
+++ b/src/containers/Proposals/components/ProposalModal/Proposals.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, InputAdornment, Typography } from '@mui/material'
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'store'
 import { AccountBalanceWalletRounded as AccountBalanceWalletRoundedIcon } from '@mui/icons-material'
 import Dropdown from 'components/Dropdown'
@@ -15,6 +15,8 @@ import {
   ProposalModalProps,
   ProposalTypes
 } from 'store/modal'
+import { getWalletBalance } from 'utils/projectUtils'
+import { updateUser } from 'store/profile'
 import {
   CancelRoundedIcon,
   InputContainer,
@@ -39,6 +41,8 @@ const Proposals: React.FC<ProposalProps> = ({ handleModal, modalProps }) => {
   const [proposal, setProposal] = useState<string>('1')
   const [title, setTitle] = useState<string>('')
   const [proposalError, setProposalError] = useState<boolean>()
+
+  const dispatch = useDispatch()
 
   const delayInput = _.debounce(
     (value) =>
@@ -101,6 +105,14 @@ const Proposals: React.FC<ProposalProps> = ({ handleModal, modalProps }) => {
         fee: new BigNumber(gasFee),
         hash: result.transactionHash
       })
+
+      const walletBalance = await getWalletBalance(address)
+
+      dispatch(
+        updateUser({
+          balance: walletBalance
+        })
+      )
     } catch (error) {
       handleModal({
         open: true,

--- a/src/containers/ValidatorDetails/components/Details/components/ValidatorInfo/components/RedelegationModal/Redelegation.tsx
+++ b/src/containers/ValidatorDetails/components/Details/components/ValidatorInfo/components/RedelegationModal/Redelegation.tsx
@@ -424,7 +424,8 @@ const Redelegation: React.FC<RedelegationProps> = ({
             disabled={
               Number(amount) > Number(delegated) ||
               !amount ||
-              !redelegationAddress
+              !redelegationAddress ||
+              fee.length <= 0
             }
           >
             Submit

--- a/src/containers/ValidatorDetails/components/Details/components/ValidatorInfo/components/UndelegationModal/Undelegation.tsx
+++ b/src/containers/ValidatorDetails/components/Details/components/ValidatorInfo/components/UndelegationModal/Undelegation.tsx
@@ -402,7 +402,9 @@ const Undelegation: React.FC<UndelegationProps> = ({
               width: '50%'
             })}
             onClick={handleSubmit}
-            disabled={Number(amount) > Number(delegated) || !amount}
+            disabled={
+              Number(amount) > Number(delegated) || !amount || fee.length <= 0
+            }
           >
             Submit
           </Button>


### PR DESCRIPTION
fix: Wallet balance should update immediately after transaction has been completed.
fix [`Delegation Modal, Undelegation Modal, Redelegation Modal`]: If you do not wait for the `Transaction Summary` to calculate the `Estimated Transaction fee` and click `Submit`, Loading modal will show and then close and open a new empty modal.