### PR TITLE
CUDOS-1786 Restake stays on

### DIFF
--- a/src/ledgers/transactions.ts
+++ b/src/ledgers/transactions.ts
@@ -280,7 +280,7 @@ export const claimRewards = async (
 
   const result = await client.signAndBroadcast(address, msgAny, fee, msgMemo)
 
-  if (claimAndRestakeSeparateMsg) {
+  if (claimAndRestakeSeparateMsg && restake) {
     stakedValidators.forEach((validator) => {
       if (Number(validator.amount) > 0) {
         msgRestake.push({


### PR DESCRIPTION
fix: Restake functionality stays on, even if user turns it off. This happens only when `Rewards `> `Available balance`