### PR TITLE
CUDOS-1747 Claim reward single

### DIFF
--- a/src/containers/Dashboard/WalletInformation/index.tsx
+++ b/src/containers/Dashboard/WalletInformation/index.tsx
@@ -273,6 +273,7 @@ const WalletInformation: React.FC = () => {
                 handleRewardsModal({
                   open: true,
                   status: ModalStatus.IN_PROGRESS,
+                  isSingleRewardWithdraw: false,
                   amount: availableRewards.toString()
                 })
               }

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -42,6 +42,7 @@ export type RewardsModalProps = Modal & {
     imageUrl: string
     address: string
   } | null
+  isSingleRewardWithdraw: boolean
   amount: string | null
   fee: string
   txHash?: string
@@ -52,6 +53,7 @@ export type RewardsModalProps = Modal & {
 export const initialRewardsModalProps: RewardsModalProps = {
   open: false,
   status: null,
+  isSingleRewardWithdraw: false,
   validator: null,
   amount: null,
   fee: '',


### PR DESCRIPTION
feat: There is a case where a user might have a small delegation to a certain validator and larger delegations to another. The user might want to avoid having to pay for claiming the small amount from the first validator and wishes to only claim the larger portion of the rewards.